### PR TITLE
Fix/update linting

### DIFF
--- a/.eslintrc.full.json
+++ b/.eslintrc.full.json
@@ -7,5 +7,11 @@
   ],
   "parserOptions": {
     "project": "./tsconfig.json"
+  },
+  "rules": {
+    // Allow passing an async function to through2.obj()
+    "@typescript-eslint/no-misused-promises": ["error", {
+        "checksVoidReturn": false
+    }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,10 @@
       "devDependencies": true
     }],
 
+    // This rule doesn't yet handle TypeScript's `import type` syntax
+    // https://github.com/benmosher/eslint-plugin-import/issues/1667
+    "import/no-duplicates": "off",
+
     // Use type inference to reduce duplicated definitions (types and values)
     "@typescript-eslint/explicit-function-return-type": "off"
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,12 +38,7 @@
     }],
 
     // Use type inference to reduce duplicated definitions (types and values)
-    "@typescript-eslint/explicit-function-return-type": "off",
-
-    // Allow passing an async function to through2.obj()
-    "@typescript-eslint/no-misused-promises": ["error", {
-        "checksVoidReturn": false
-    }]
+    "@typescript-eslint/explicit-function-return-type": "off"
   },
   "overrides": [{
     "files": ["src/**/*.ts"],

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
-import typescript from 'rollup-plugin-typescript2';
+import type RollupTypescript from 'rollup-plugin-typescript2';
 
-import {ResizeImagesOptions} from './lib/gulp-resize-images';
+import type {ResizeImagesOptions} from './lib/gulp-resize-images';
 
 export const PATHS = {
   srcRoot: 'src/' as const,
@@ -77,7 +77,7 @@ const resizeImagesFeatured: ResizeImagesOptions = {
   ],
 };
 
-const rollupTypescript: Parameters<typeof typescript>[0] = {
+const rollupTypescript: Parameters<typeof RollupTypescript>[0] = {
   check: false, // Faster (we lint and type check separately)
   clean: true, // Don't cache -- a little slower, but more robust
   tsconfigOverride: {

--- a/lib/gulp-resize-images.ts
+++ b/lib/gulp-resize-images.ts
@@ -1,7 +1,8 @@
 import sharp from 'sharp';
 import * as through2 from 'through2';
+// We don't depend on vinyl directly, we just use its types to interop with gulp
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as Vinyl from 'vinyl'; // Imported only for the type definition
+import type * as Vinyl from 'vinyl';
 
 interface FormatSpecifier {
   filetype: keyof sharp.FormatEnum;

--- a/lib/gulp-rollup.ts
+++ b/lib/gulp-rollup.ts
@@ -1,11 +1,9 @@
-import {
-  rollup as rollupOriginal,
-  Plugin as RollupPlugin,
-  OutputChunk,
-} from 'rollup';
+import {rollup as rollupOriginal} from 'rollup';
+import type {Plugin as RollupPlugin, OutputChunk} from 'rollup';
 import * as through2 from 'through2';
+// We don't depend on vinyl directly, we just use its types to interop with gulp
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as Vinyl from 'vinyl'; // Imported only for the type definition
+import type * as Vinyl from 'vinyl';
 
 export function rollup({plugins = [] as RollupPlugin[]} = {}) {
   return through2.obj(async function transform(file: Vinyl, _encoding, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,12 +178,12 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.18.0.tgz",
-      "integrity": "sha512-kuO8WQjV+RCZvAXVRJfXWiJ8iYEtfHlKgcqqqXg9uUkIolEHuUaMmm8/lcO4xwCOtaw6mY0gStn2Lg4/eUXXYQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.22.0.tgz",
+      "integrity": "sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.18.0",
+        "@typescript-eslint/experimental-utils": "2.22.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -191,32 +191,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.18.0.tgz",
-      "integrity": "sha512-J6MopKPHuJYmQUkANLip7g9I82ZLe1naCbxZZW3O2sIxTiq/9YYoOELEKY7oPg0hJ0V/AQ225h2z0Yp+RRMXhw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.22.0.tgz",
+      "integrity": "sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.18.0",
+        "@typescript-eslint/typescript-estree": "2.22.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.18.0.tgz",
-      "integrity": "sha512-SJJPxFMEYEWkM6pGfcnjLU+NJIPo+Ko1QrCBL+i0+zV30ggLD90huEmMMhKLHBpESWy9lVEeWlQibweNQzyc+A==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.22.0.tgz",
+      "integrity": "sha512-FaZKC1X+nvD7qMPqKFUYHz3H0TAioSVFGvG29f796Nc5tBluoqfHgLbSFKsh7mKjRoeTm8J9WX2Wo9EyZWjG7w==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.18.0",
-        "@typescript-eslint/typescript-estree": "2.18.0",
+        "@typescript-eslint/experimental-utils": "2.22.0",
+        "@typescript-eslint/typescript-estree": "2.22.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.18.0.tgz",
-      "integrity": "sha512-gVHylf7FDb8VSi2ypFuEL3hOtoC4HkZZ5dOjXvVjoyKdRrvXAOPSzpNRnKMfaUUEiSLP8UF9j9X9EDLxC0lfZg==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz",
+      "integrity": "sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -236,12 +236,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -2147,13 +2141,13 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-      "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+      "integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^3.0.0",
+        "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
       },
       "dependencies": {
@@ -3946,10 +3940,16 @@
         }
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
     "make-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -5197,9 +5197,9 @@
       }
     },
     "rollup": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.30.1.tgz",
-      "integrity": "sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.0.tgz",
+      "integrity": "sha512-ab2tF5pdDqm2zuI8j02ceyrJSScl9V2C24FgWQ1v1kTFTu1UrG5H0hpP++mDZlEFyZX4k0chtGEHU2i+pAzBgA==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -5232,22 +5232,22 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.25.3.tgz",
-      "integrity": "sha512-ADkSaidKBovJmf5VBnZBZe+WzaZwofuvYdzGAKTN/J4hN7QJCFYAq7IrH9caxlru6T5qhX41PNFS1S4HqhsGQg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.26.0.tgz",
+      "integrity": "sha512-lUK7XZVG77tu8dmv1L/0LZFlavED/5Yo6e4iMMl6fdox/yKdj4IFRRPPJEXNdmEaT1nDQQeCi7b5IwKHffMNeg==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "^3.0.0",
+        "find-cache-dir": "^3.2.0",
         "fs-extra": "8.1.0",
-        "resolve": "1.12.0",
-        "rollup-pluginutils": "2.8.1",
+        "resolve": "1.15.1",
+        "rollup-pluginutils": "2.8.2",
         "tslib": "1.10.0"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -5256,20 +5256,12 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-      "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        }
       }
     },
     "run-async": {
@@ -6156,9 +6148,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "@types/gulp": "~4.0.6",
     "@types/sharp": "~0.24.0",
     "@types/through2": "~2.0.34",
-    "@typescript-eslint/eslint-plugin": "~2.18.0",
-    "@typescript-eslint/parser": "~2.18.0",
+    "@typescript-eslint/eslint-plugin": "~2.22.0",
+    "@typescript-eslint/parser": "~2.22.0",
     "del": "~5.1.0",
     "eslint": "~6.8.0",
     "eslint-config-airbnb-base": "~14.0.0",
     "eslint-plugin-import": "~2.20.1",
     "gulp": "~4.0.2",
-    "rollup": "~1.30.1",
+    "rollup": "~1.32.0",
     "rollup-plugin-terser": "~5.2.0",
-    "rollup-plugin-typescript2": "~0.25.3",
+    "rollup-plugin-typescript2": "~0.26.0",
     "sharp": "~0.24.1",
     "through2": "~3.0.1",
     "ts-node": "~8.6.2",
-    "typescript": "~3.7.5"
+    "typescript": "~3.8.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "importHelpers": true,
+    "importsNotUsedAsValues": "error",
     "lib": ["dom", "es5", "es2019.array"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
* Fix fast linting with `.eslintrc.json` (the thorough linting is done with `.eslintrc.full.json`)
* Use TypeScript's new [`import type` syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-rc/#type-only-imports-exports)